### PR TITLE
werkzeug seems to have a bug, service fails with "no such file"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flask
+werkzeug==0.14.1


### PR DESCRIPTION
See  https://stackoverflow.com/questions/55336316/flask-cli-throws-errno-2-no-such-file-when-deploying-with-docker